### PR TITLE
Port SentimentAnalysis to Py3 on arm64

### DIFF
--- a/sample-functions/SentimentAnalysis/Dockerfile.arm64
+++ b/sample-functions/SentimentAnalysis/Dockerfile.arm64
@@ -1,0 +1,31 @@
+FROM openfaas/classic-watchdog:0.18.8 as watchdog
+
+FROM arm64v8/python:3-slim
+
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+RUN python -m textblob.download_corpora
+
+COPY --from=watchdog /fwatchdog /usr/bin/fwatchdog
+RUN chmod +x /usr/bin/fwatchdog
+
+RUN addgroup --gid 1000 --system app 
+RUN adduser --uid 1000 --system app 
+USER 1000
+
+WORKDIR /home/app
+
+COPY requirements.txt   .
+RUN pip install -r requirements.txt
+
+RUN python -m textblob.download_corpora
+
+COPY handler.py .
+ENV fprocess="python handler.py"
+
+HEALTHCHECK --interval=3s CMD [ -e /tmp/.lock ] || exit 1
+
+CMD ["fwatchdog"]
+
+

--- a/sample-functions/SentimentAnalysis/handler.py
+++ b/sample-functions/SentimentAnalysis/handler.py
@@ -3,8 +3,10 @@ import json
 from textblob import TextBlob
 
 # Set encoding to UTF-8 (vs ASCII to eliminate potential errors).
-reload(sys)
-sys.setdefaultencoding('utf8')
+
+if sys.version[0] == '2':
+    reload(sys)
+    sys.setdefaultencoding("utf-8")
 
 def get_stdin():
     buf = ""


### PR DESCRIPTION
Currently, the SentimentAnalysis function has no arm64 flavor. This PR adds it.

## Description
Used arm64 docker, python3, built and tested it on a RPi4.


## Motivation and Context

- [x] I have raised an issue to propose this change ([required](https://github.com/openfaas/faas/blob/master /CONTRIBUTING.md)) - Issue [1587](https://github.com/openfaas/faas/issues/1587).
- [ ] My issue has received approval from the maintainers or lead with the `design/approved` label.


## How Has This Been Tested?

Manually tested on RPi4.
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)


## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/openfaas/faas/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
